### PR TITLE
discard redo history when document is closed

### DIFF
--- a/Screenshot Framer/Document.swift
+++ b/Screenshot Framer/Document.swift
@@ -62,6 +62,16 @@ final class Document: NSDocument {
         return true
     }
 
+    override func canClose(withDelegate delegate: Any, shouldClose shouldCloseSelector: Selector?, contextInfo: UnsafeMutableRawPointer?) {
+        self.layerStateHistory.discardRedoHistory()
+
+        if self.isDocumentEdited && self.fileURL != nil {
+            self.save(nil)
+        }
+        self.close()
+    }
+
+
     // Responder Chain
 
     @IBAction func showTimeTravelWindow(_ sender: AnyObject?) {

--- a/Screenshot Framer/Model/LayerStateHistory.swift
+++ b/Screenshot Framer/Model/LayerStateHistory.swift
@@ -57,6 +57,14 @@ final class LayerStateHistory {
         self.notifyLayerStateDidChange()
     }
 
+    @discardableResult func discardRedoHistory() -> Bool {
+        guard self.currentStackPosition < self.layerStates.count - 1 else { return false }
+
+        let delta = (self.layerStates.count - 1) - self.currentStackPosition
+        self.layerStates.removeLast(delta)
+        return true
+    }
+
 
     // MARK: - Undo / Redo
 

--- a/Screenshot Framer/Supporting Files/Info.plist
+++ b/Screenshot Framer/Supporting Files/Info.plist
@@ -40,7 +40,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>3</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
Until now when a document was closed with undo applied the document opened in an incorrect state (undo was ignored before opening the document). 
To fix this the redo stack is discarded before the document is closed.