### PR TITLE
Fix Layout Issue in generated Website

### DIFF
--- a/Screenshot Framer CLI/WebsiteBuilder.swift
+++ b/Screenshot Framer CLI/WebsiteBuilder.swift
@@ -199,7 +199,7 @@ private extension WebsiteBuilder {
         let tableRow = Element(Tag("tr"), "")
 
         let tableHeader = Element(Tag("th"), "")
-        try tableHeader.attr("colspan", "1")
+        try tableHeader.attr("colspan", "100%")
 
         let content = Element(Tag("a"), "")
         try content.attr("id", device)

--- a/Screenshot Framer CLI/main.swift
+++ b/Screenshot Framer CLI/main.swift
@@ -12,7 +12,7 @@ struct ScreenshotFramer: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         abstract: "A Swift command-line tool to frame localised screenshots for the AppStore",
-        version: "2.0",
+        version: "2.0.1",
         subcommands: [Export.self, Website.self])
 
     init() { }

--- a/Screenshot Framer CLI/main.swift
+++ b/Screenshot Framer CLI/main.swift
@@ -12,7 +12,7 @@ struct ScreenshotFramer: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         abstract: "A Swift command-line tool to frame localised screenshots for the AppStore",
-        version: "2.0"
+        version: "2.0",
         subcommands: [Export.self, Website.self])
 
     init() { }

--- a/Screenshot Framer/Time Travel/TimeTravelWindowController.swift
+++ b/Screenshot Framer/Time Travel/TimeTravelWindowController.swift
@@ -24,7 +24,7 @@ final class TimeTravelWindowController: NSWindowController {
 
     override var document: AnyObject? {
         get { return nil }
-        set {}  // swiftlint:disable:this unused_setter_value
+        set {}
     }
 
 


### PR DESCRIPTION
### Description

Layout of generated website had an issue if the device name was bigger than the image.

### Task

- [x] Render title over full width of table instead of one element

### Result

![Result](https://user-images.githubusercontent.com/18739004/168596464-c53e3d32-833c-480f-94bf-c472db41e621.png)
